### PR TITLE
add reflection service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/gunk/gunk-example-server
 
 require (
 	github.com/golang/protobuf v1.2.0
-	golang.org/x/net v0.0.0-20181217023233-e147a9138326
+	golang.org/x/net v0.0.0-20181217023233-e147a9138326 // indirect
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	golang.org/x/sys v0.0.0-20181218192612-074acd46bca6 // indirect
 	google.golang.org/genproto v0.0.0-20181218023534-67d6565462c5

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	goog "github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/gunk/gunk-example-server/v1/util"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 // Server is a util server.
@@ -36,6 +37,7 @@ func main() {
 		log.Fatal(err)
 	}
 	s := grpc.NewServer()
+	reflection.Register(s)
 	pb.RegisterUtilServer(s, &Server{})
 	log.Fatal(s.Serve(l))
 }


### PR DESCRIPTION
This commit adds the use of reflection service to allow common tools for interacting with GRPC server (such as [grpcurl](https://github.com/fullstorydev/grpcurl)) to work.